### PR TITLE
Add helper script to run app

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Click on above image to watch the demo or use this link https://youtu.be/gMbB1fW
 4. Open `secrets.py` file in `/config` folder and enter your LinkedIn username, password to login and OpenAI API Key for generation of job tailored resumes and cover letters (This entire step is optional). If you do not provide username or password or leave them as default, it will login with saved profile in browser, if failed will ask you to login manually.
 5. Open `settings.py` file in `/config` folder to configure the bot settings like, keep screen awake, click intervals (click intervals are randomized to seem like human behavior), run in background, stealth mode (to avoid bot detection), etc. as per your needs.
 6. (Optional) Don't forget to add you default resume in the location you mentioned in `default_resume_path = "all resumes/default/resume.pdf"` given in `/config/questions.py`. If one is not provided, it will use your previous resume submitted in LinkedIn or (In Development) generate custom resume if OpenAI APT key is provided!
-7. Run `runAiBot.py` and see the magic happen.
+7. Run `./run.sh` to automatically activate the virtual environment and launch `runAiBot.py`.
 8. To run the Applied Jobs history UI, run `app.py` and open web browser on `http://localhost:5000`.
 8. If you have questions or need help setting it up or to talk in general, join the github server: https://discord.gg/fFp7uUzWCY
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run Auto Job Applier with virtual environment activation
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PATH="$SCRIPT_DIR/setup/.venv"
+
+if [ ! -d "$VENV_PATH" ]; then
+  echo "Virtual environment not found at $VENV_PATH" >&2
+  echo "Run setup/setup_venv.sh first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_PATH/bin/activate"
+
+python runAiBot.py "$@"


### PR DESCRIPTION
## Summary
- Add `run.sh` to activate the virtual environment and start the job applier.
- Update README instructions to use `./run.sh` for launching the bot.

## Testing
- `bash -n run.sh`
- `pytest -q` *(fails: KeyError: 'DISPLAY')*


------
https://chatgpt.com/codex/tasks/task_b_68a4065f197c832381d73a5ef65b154e