### PR TITLE
Ensure run script installs dependencies

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,4 +15,10 @@ fi
 # shellcheck disable=SC1090
 source "$VENV_PATH/bin/activate"
 
+# Ensure required dependencies are installed
+if ! python -c "import pyautogui" >/dev/null 2>&1; then
+  echo "Installing Python dependencies..."
+  pip install -r "$SCRIPT_DIR/requirements.txt"
+fi
+
 python runAiBot.py "$@"


### PR DESCRIPTION
## Summary
- Detect missing pyautogui in run.sh and automatically install requirements before launching the bot

## Testing
- `bash setup/setup_venv.sh` *(fails: ProxyError Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile runAiBot.py`


------
https://chatgpt.com/codex/tasks/task_b_68a407f0ed5083238fc0e267efc9839f